### PR TITLE
feat: standardize event handler coverage across all components

### DIFF
--- a/projects/ngx-recharts-lib/src/lib/cartesian/area.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/area.component.ts
@@ -54,6 +54,11 @@ export interface AreaPoint {
         [attr.stroke]="stroke()"
         [attr.stroke-width]="strokeWidth()"
         (click)="handleAreaClick($event)"
+        (mousedown)="handleAreaMouseDown($event)"
+        (mouseup)="handleAreaMouseUp($event)"
+        (mousemove)="handleAreaMouseMove($event)"
+        (mouseover)="handleAreaMouseOver($event)"
+        (mouseout)="handleAreaMouseOut($event)"
         (mouseenter)="handleAreaMouseEnter($event)"
         (mouseleave)="handleAreaMouseLeave($event)" />
       
@@ -149,6 +154,11 @@ export class AreaComponent implements OnDestroy {
   categoryKey = input<string>('name');
 
   areaClick = output<ChartMouseEvent>();
+  areaMouseDown = output<ChartMouseEvent>();
+  areaMouseUp = output<ChartMouseEvent>();
+  areaMouseMove = output<ChartMouseEvent>();
+  areaMouseOver = output<ChartMouseEvent>();
+  areaMouseOut = output<ChartMouseEvent>();
   areaMouseEnter = output<ChartMouseEvent>();
   areaMouseLeave = output<ChartMouseEvent>();
 
@@ -388,6 +398,51 @@ export class AreaComponent implements OnDestroy {
 
   handleAreaMouseEnter(event: MouseEvent) {
     this.areaMouseEnter.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleAreaMouseDown(event: MouseEvent) {
+    this.areaMouseDown.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleAreaMouseUp(event: MouseEvent) {
+    this.areaMouseUp.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleAreaMouseMove(event: MouseEvent) {
+    this.areaMouseMove.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleAreaMouseOver(event: MouseEvent) {
+    this.areaMouseOver.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleAreaMouseOut(event: MouseEvent) {
+    this.areaMouseOut.emit({
       nativeEvent: event,
       dataKey: this.dataKey() as string,
       payload: this.resolvedData(),

--- a/projects/ngx-recharts-lib/src/lib/cartesian/bar.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/bar.component.ts
@@ -57,6 +57,11 @@ export interface BarRect {
           [attr.ry]="resolvedRadius()"
           [style.transition]="isAnimationActive() ? 'all ' + animationDuration() + 'ms ' + animationEasing() + ' ' + animationBegin() + 'ms' : null"
           (click)="handleBarClick($event, bar.payload, $index)"
+          (mousedown)="handleBarMouseDown($event, bar.payload, $index)"
+          (mouseup)="handleBarMouseUp($event, bar.payload, $index)"
+          (mousemove)="handleBarMouseMove($event, bar.payload, $index)"
+          (mouseover)="handleBarMouseOver($event, bar.payload, $index)"
+          (mouseout)="handleBarMouseOut($event, bar.payload, $index)"
           (mouseenter)="handleBarMouseEnter($event, bar.payload, $index)"
           (mouseleave)="handleBarMouseLeave($event, bar.payload, $index)" />
         @if (label()) {
@@ -131,6 +136,11 @@ export class BarComponent implements OnDestroy {
   activeIndex = input<number>(-1);
 
   barClick = output<ChartMouseEvent>();
+  barMouseDown = output<ChartMouseEvent>();
+  barMouseUp = output<ChartMouseEvent>();
+  barMouseMove = output<ChartMouseEvent>();
+  barMouseOver = output<ChartMouseEvent>();
+  barMouseOut = output<ChartMouseEvent>();
   barMouseEnter = output<ChartMouseEvent>();
   barMouseLeave = output<ChartMouseEvent>();
 
@@ -172,6 +182,56 @@ export class BarComponent implements OnDestroy {
 
   handleBarMouseEnter(event: MouseEvent, data: any, index: number) {
     this.barMouseEnter.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: data,
+      index,
+      value: data?.[this.dataKey() as string],
+    });
+  }
+
+  handleBarMouseDown(event: MouseEvent, data: any, index: number) {
+    this.barMouseDown.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: data,
+      index,
+      value: data?.[this.dataKey() as string],
+    });
+  }
+
+  handleBarMouseUp(event: MouseEvent, data: any, index: number) {
+    this.barMouseUp.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: data,
+      index,
+      value: data?.[this.dataKey() as string],
+    });
+  }
+
+  handleBarMouseMove(event: MouseEvent, data: any, index: number) {
+    this.barMouseMove.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: data,
+      index,
+      value: data?.[this.dataKey() as string],
+    });
+  }
+
+  handleBarMouseOver(event: MouseEvent, data: any, index: number) {
+    this.barMouseOver.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: data,
+      index,
+      value: data?.[this.dataKey() as string],
+    });
+  }
+
+  handleBarMouseOut(event: MouseEvent, data: any, index: number) {
+    this.barMouseOut.emit({
       nativeEvent: event,
       dataKey: this.dataKey() as string,
       payload: data,

--- a/projects/ngx-recharts-lib/src/lib/cartesian/funnel.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/funnel.component.ts
@@ -40,6 +40,11 @@ export interface FunnelSegment {
         @if ($last && lastShapeType() === 'rectangle') {
           <svg:g
             (click)="handleFunnelClick($event, segment, $index)"
+            (mousedown)="handleFunnelMouseDown($event, segment, $index)"
+            (mouseup)="handleFunnelMouseUp($event, segment, $index)"
+            (mousemove)="handleFunnelMouseMove($event, segment, $index)"
+            (mouseover)="handleFunnelMouseOver($event, segment, $index)"
+            (mouseout)="handleFunnelMouseOut($event, segment, $index)"
             (mouseenter)="handleFunnelMouseEnter($event, segment, $index)"
             (mouseleave)="handleFunnelMouseLeave($event, segment, $index)"
           >
@@ -48,6 +53,11 @@ export interface FunnelSegment {
         } @else {
           <svg:g
             (click)="handleFunnelClick($event, segment, $index)"
+            (mousedown)="handleFunnelMouseDown($event, segment, $index)"
+            (mouseup)="handleFunnelMouseUp($event, segment, $index)"
+            (mousemove)="handleFunnelMouseMove($event, segment, $index)"
+            (mouseover)="handleFunnelMouseOver($event, segment, $index)"
+            (mouseout)="handleFunnelMouseOut($event, segment, $index)"
             (mouseenter)="handleFunnelMouseEnter($event, segment, $index)"
             (mouseleave)="handleFunnelMouseLeave($event, segment, $index)"
           >
@@ -86,6 +96,11 @@ export class FunnelComponent implements OnDestroy {
 
   // Event outputs
   funnelClick = output<ChartMouseEvent>();
+  funnelMouseDown = output<ChartMouseEvent>();
+  funnelMouseUp = output<ChartMouseEvent>();
+  funnelMouseMove = output<ChartMouseEvent>();
+  funnelMouseOver = output<ChartMouseEvent>();
+  funnelMouseOut = output<ChartMouseEvent>();
   funnelMouseEnter = output<ChartMouseEvent>();
   funnelMouseLeave = output<ChartMouseEvent>();
 
@@ -101,6 +116,56 @@ export class FunnelComponent implements OnDestroy {
 
   handleFunnelMouseEnter(event: MouseEvent, segment: FunnelSegment, index: number) {
     this.funnelMouseEnter.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: segment,
+      index,
+      value: segment.value,
+    });
+  }
+
+  handleFunnelMouseDown(event: MouseEvent, segment: FunnelSegment, index: number) {
+    this.funnelMouseDown.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: segment,
+      index,
+      value: segment.value,
+    });
+  }
+
+  handleFunnelMouseUp(event: MouseEvent, segment: FunnelSegment, index: number) {
+    this.funnelMouseUp.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: segment,
+      index,
+      value: segment.value,
+    });
+  }
+
+  handleFunnelMouseMove(event: MouseEvent, segment: FunnelSegment, index: number) {
+    this.funnelMouseMove.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: segment,
+      index,
+      value: segment.value,
+    });
+  }
+
+  handleFunnelMouseOver(event: MouseEvent, segment: FunnelSegment, index: number) {
+    this.funnelMouseOver.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: segment,
+      index,
+      value: segment.value,
+    });
+  }
+
+  handleFunnelMouseOut(event: MouseEvent, segment: FunnelSegment, index: number) {
+    this.funnelMouseOut.emit({
       nativeEvent: event,
       dataKey: this.dataKey(),
       payload: segment,

--- a/projects/ngx-recharts-lib/src/lib/cartesian/reference-area.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/reference-area.component.ts
@@ -4,7 +4,9 @@ import {
   computed,
   inject,
   input,
+  output,
 } from '@angular/core';
+import { ChartMouseEvent } from '../core/event-types';
 import { AxisRegistryService } from '../services/axis-registry.service';
 import { ResponsiveContainerService } from '../services/responsive-container.service';
 import { RectangleComponent } from '../shape/rectangle.component';
@@ -17,27 +19,38 @@ import { RectangleComponent } from '../shape/rectangle.component';
   template: `
     @if (rectCoords(); as coords) {
       <svg:g
-        ngx-rectangle
-        [x]="coords.x"
-        [y]="coords.y"
-        [width]="coords.width"
-        [height]="coords.height"
-        [fill]="fill()"
-        [stroke]="stroke()"
-        [strokeWidth]="1"
-        [attr.fill-opacity]="fillOpacity()"
-        [attr.stroke-opacity]="strokeOpacity()"
-      />
-      @if (label()) {
-        <svg:text
-          class="recharts-label"
-          [attr.x]="coords.x + coords.width / 2"
-          [attr.y]="coords.y + coords.height / 2"
-          text-anchor="middle"
-          dominant-baseline="central"
-          fill="#666"
-        >{{ label() }}</svg:text>
-      }
+        (click)="handleClick($event)"
+        (mousedown)="handleMouseDown($event)"
+        (mouseup)="handleMouseUp($event)"
+        (mousemove)="handleMouseMove($event)"
+        (mouseover)="handleMouseOver($event)"
+        (mouseout)="handleMouseOut($event)"
+        (mouseenter)="handleMouseEnter($event)"
+        (mouseleave)="handleMouseLeave($event)"
+      >
+        <svg:g
+          ngx-rectangle
+          [x]="coords.x"
+          [y]="coords.y"
+          [width]="coords.width"
+          [height]="coords.height"
+          [fill]="fill()"
+          [stroke]="stroke()"
+          [strokeWidth]="1"
+          [attr.fill-opacity]="fillOpacity()"
+          [attr.stroke-opacity]="strokeOpacity()"
+        />
+        @if (label()) {
+          <svg:text
+            class="recharts-label"
+            [attr.x]="coords.x + coords.width / 2"
+            [attr.y]="coords.y + coords.height / 2"
+            text-anchor="middle"
+            dominant-baseline="central"
+            fill="#666"
+          >{{ label() }}</svg:text>
+        }
+      </svg:g>
     }
   `,
 })
@@ -57,6 +70,33 @@ export class ReferenceAreaComponent {
   strokeOpacity = input<number>(1);
   label = input<string | undefined>(undefined);
   ifOverflow = input<string>('discard');
+
+  // Event outputs
+  refAreaClick = output<ChartMouseEvent>();
+  refAreaMouseDown = output<ChartMouseEvent>();
+  refAreaMouseUp = output<ChartMouseEvent>();
+  refAreaMouseMove = output<ChartMouseEvent>();
+  refAreaMouseOver = output<ChartMouseEvent>();
+  refAreaMouseOut = output<ChartMouseEvent>();
+  refAreaMouseEnter = output<ChartMouseEvent>();
+  refAreaMouseLeave = output<ChartMouseEvent>();
+
+  private emitEvent(event: MouseEvent): ChartMouseEvent {
+    return {
+      nativeEvent: event,
+      payload: { x1: this.x1(), x2: this.x2(), y1: this.y1(), y2: this.y2() },
+      index: 0,
+    };
+  }
+
+  handleClick(event: MouseEvent) { this.refAreaClick.emit(this.emitEvent(event)); }
+  handleMouseDown(event: MouseEvent) { this.refAreaMouseDown.emit(this.emitEvent(event)); }
+  handleMouseUp(event: MouseEvent) { this.refAreaMouseUp.emit(this.emitEvent(event)); }
+  handleMouseMove(event: MouseEvent) { this.refAreaMouseMove.emit(this.emitEvent(event)); }
+  handleMouseOver(event: MouseEvent) { this.refAreaMouseOver.emit(this.emitEvent(event)); }
+  handleMouseOut(event: MouseEvent) { this.refAreaMouseOut.emit(this.emitEvent(event)); }
+  handleMouseEnter(event: MouseEvent) { this.refAreaMouseEnter.emit(this.emitEvent(event)); }
+  handleMouseLeave(event: MouseEvent) { this.refAreaMouseLeave.emit(this.emitEvent(event)); }
 
   private plotWidth = computed(() => this.responsiveService?.plotWidth() ?? 400);
   private plotHeight = computed(() => this.responsiveService?.plotHeight() ?? 300);

--- a/projects/ngx-recharts-lib/src/lib/cartesian/reference-dot.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/reference-dot.component.ts
@@ -4,7 +4,9 @@ import {
   computed,
   inject,
   input,
+  output,
 } from '@angular/core';
+import { ChartMouseEvent } from '../core/event-types';
 import { AxisRegistryService } from '../services/axis-registry.service';
 import { ResponsiveContainerService } from '../services/responsive-container.service';
 import { DotComponent } from '../shape/dot.component';
@@ -17,23 +19,34 @@ import { DotComponent } from '../shape/dot.component';
   template: `
     @if (pixelCoords(); as coords) {
       <svg:g
-        ngx-dot
-        [cx]="coords.x"
-        [cy]="coords.y"
-        [r]="r()"
-        [fill]="fill()"
-        [stroke]="stroke()"
-        [strokeWidth]="strokeWidth()"
-      />
-      @if (label()) {
-        <svg:text
-          class="recharts-label"
-          [attr.x]="coords.x"
-          [attr.y]="coords.y - r() - 4"
-          text-anchor="middle"
-          fill="#666"
-        >{{ label() }}</svg:text>
-      }
+        (click)="handleClick($event)"
+        (mousedown)="handleMouseDown($event)"
+        (mouseup)="handleMouseUp($event)"
+        (mousemove)="handleMouseMove($event)"
+        (mouseover)="handleMouseOver($event)"
+        (mouseout)="handleMouseOut($event)"
+        (mouseenter)="handleMouseEnter($event)"
+        (mouseleave)="handleMouseLeave($event)"
+      >
+        <svg:g
+          ngx-dot
+          [cx]="coords.x"
+          [cy]="coords.y"
+          [r]="r()"
+          [fill]="fill()"
+          [stroke]="stroke()"
+          [strokeWidth]="strokeWidth()"
+        />
+        @if (label()) {
+          <svg:text
+            class="recharts-label"
+            [attr.x]="coords.x"
+            [attr.y]="coords.y - r() - 4"
+            text-anchor="middle"
+            fill="#666"
+          >{{ label() }}</svg:text>
+        }
+      </svg:g>
     }
   `,
 })
@@ -51,6 +64,33 @@ export class ReferenceDotComponent {
   strokeWidth = input<number>(1);
   label = input<string | undefined>(undefined);
   ifOverflow = input<string>('discard');
+
+  // Event outputs
+  refDotClick = output<ChartMouseEvent>();
+  refDotMouseDown = output<ChartMouseEvent>();
+  refDotMouseUp = output<ChartMouseEvent>();
+  refDotMouseMove = output<ChartMouseEvent>();
+  refDotMouseOver = output<ChartMouseEvent>();
+  refDotMouseOut = output<ChartMouseEvent>();
+  refDotMouseEnter = output<ChartMouseEvent>();
+  refDotMouseLeave = output<ChartMouseEvent>();
+
+  private emitEvent(event: MouseEvent): ChartMouseEvent {
+    return {
+      nativeEvent: event,
+      payload: { x: this.x(), y: this.y() },
+      index: 0,
+    };
+  }
+
+  handleClick(event: MouseEvent) { this.refDotClick.emit(this.emitEvent(event)); }
+  handleMouseDown(event: MouseEvent) { this.refDotMouseDown.emit(this.emitEvent(event)); }
+  handleMouseUp(event: MouseEvent) { this.refDotMouseUp.emit(this.emitEvent(event)); }
+  handleMouseMove(event: MouseEvent) { this.refDotMouseMove.emit(this.emitEvent(event)); }
+  handleMouseOver(event: MouseEvent) { this.refDotMouseOver.emit(this.emitEvent(event)); }
+  handleMouseOut(event: MouseEvent) { this.refDotMouseOut.emit(this.emitEvent(event)); }
+  handleMouseEnter(event: MouseEvent) { this.refDotMouseEnter.emit(this.emitEvent(event)); }
+  handleMouseLeave(event: MouseEvent) { this.refDotMouseLeave.emit(this.emitEvent(event)); }
 
   pixelCoords = computed((): { x: number; y: number } | null => {
     const xScale = this.axisRegistry?.getXAxisScale(this.xAxisId());

--- a/projects/ngx-recharts-lib/src/lib/cartesian/reference-line.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/reference-line.component.ts
@@ -4,7 +4,9 @@ import {
   computed,
   inject,
   input,
+  output,
 } from '@angular/core';
+import { ChartMouseEvent } from '../core/event-types';
 import { AxisRegistryService } from '../services/axis-registry.service';
 import { ResponsiveContainerService } from '../services/responsive-container.service';
 
@@ -30,6 +32,14 @@ export interface ReferenceLineSegmentPoint {
         [attr.stroke-dasharray]="strokeDasharray() || null"
         [attr.fill]="fill()"
         [attr.fill-opacity]="fillOpacity()"
+        (click)="handleClick($event)"
+        (mousedown)="handleMouseDown($event)"
+        (mouseup)="handleMouseUp($event)"
+        (mousemove)="handleMouseMove($event)"
+        (mouseover)="handleMouseOver($event)"
+        (mouseout)="handleMouseOut($event)"
+        (mouseenter)="handleMouseEnter($event)"
+        (mouseleave)="handleMouseLeave($event)"
       />
       @if (label()) {
         <svg:text
@@ -59,6 +69,33 @@ export class ReferenceLineComponent {
   label = input<string | undefined>(undefined);
   ifOverflow = input<'discard' | 'hidden' | 'visible' | 'extendDomain'>('discard');
   segment = input<[ReferenceLineSegmentPoint, ReferenceLineSegmentPoint] | undefined>(undefined);
+
+  // Event outputs
+  refLineClick = output<ChartMouseEvent>();
+  refLineMouseDown = output<ChartMouseEvent>();
+  refLineMouseUp = output<ChartMouseEvent>();
+  refLineMouseMove = output<ChartMouseEvent>();
+  refLineMouseOver = output<ChartMouseEvent>();
+  refLineMouseOut = output<ChartMouseEvent>();
+  refLineMouseEnter = output<ChartMouseEvent>();
+  refLineMouseLeave = output<ChartMouseEvent>();
+
+  private emitEvent(event: MouseEvent): ChartMouseEvent {
+    return {
+      nativeEvent: event,
+      payload: { x: this.x(), y: this.y() },
+      index: 0,
+    };
+  }
+
+  handleClick(event: MouseEvent) { this.refLineClick.emit(this.emitEvent(event)); }
+  handleMouseDown(event: MouseEvent) { this.refLineMouseDown.emit(this.emitEvent(event)); }
+  handleMouseUp(event: MouseEvent) { this.refLineMouseUp.emit(this.emitEvent(event)); }
+  handleMouseMove(event: MouseEvent) { this.refLineMouseMove.emit(this.emitEvent(event)); }
+  handleMouseOver(event: MouseEvent) { this.refLineMouseOver.emit(this.emitEvent(event)); }
+  handleMouseOut(event: MouseEvent) { this.refLineMouseOut.emit(this.emitEvent(event)); }
+  handleMouseEnter(event: MouseEvent) { this.refLineMouseEnter.emit(this.emitEvent(event)); }
+  handleMouseLeave(event: MouseEvent) { this.refLineMouseLeave.emit(this.emitEvent(event)); }
 
   private plotWidth = computed(() => this.responsiveService?.plotWidth() ?? 400);
   private plotHeight = computed(() => this.responsiveService?.plotHeight() ?? 300);

--- a/projects/ngx-recharts-lib/src/lib/cartesian/scatter.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/scatter.component.ts
@@ -48,6 +48,11 @@ export interface ScatterPoint {
           [animationDuration]="animationDuration()"
           [animationEasing]="animationEasing()"
           (symbolClick)="handleScatterClick($event, point, $index)"
+          (symbolMouseDown)="handleScatterMouseDown($event, point, $index)"
+          (symbolMouseUp)="handleScatterMouseUp($event, point, $index)"
+          (symbolMouseMove)="handleScatterMouseMove($event, point, $index)"
+          (symbolMouseOver)="handleScatterMouseOver($event, point, $index)"
+          (symbolMouseOut)="handleScatterMouseOut($event, point, $index)"
           (symbolMouseEnter)="handleScatterMouseEnter($event, point, $index)"
           (symbolMouseLeave)="handleScatterMouseLeave($event, point, $index)"
         />
@@ -89,6 +94,11 @@ export class ScatterComponent implements OnDestroy {
 
   // Event outputs
   scatterClick = output<ChartMouseEvent>();
+  scatterMouseDown = output<ChartMouseEvent>();
+  scatterMouseUp = output<ChartMouseEvent>();
+  scatterMouseMove = output<ChartMouseEvent>();
+  scatterMouseOver = output<ChartMouseEvent>();
+  scatterMouseOut = output<ChartMouseEvent>();
   scatterMouseEnter = output<ChartMouseEvent>();
   scatterMouseLeave = output<ChartMouseEvent>();
 
@@ -150,6 +160,56 @@ export class ScatterComponent implements OnDestroy {
 
   handleScatterMouseEnter(event: MouseEvent, point: ScatterPoint, index: number) {
     this.scatterMouseEnter.emit({
+      nativeEvent: event,
+      payload: point.payload,
+      index,
+      value: point.payload,
+      coordinate: { x: point.x, y: point.y },
+    });
+  }
+
+  handleScatterMouseDown(event: MouseEvent, point: ScatterPoint, index: number) {
+    this.scatterMouseDown.emit({
+      nativeEvent: event,
+      payload: point.payload,
+      index,
+      value: point.payload,
+      coordinate: { x: point.x, y: point.y },
+    });
+  }
+
+  handleScatterMouseUp(event: MouseEvent, point: ScatterPoint, index: number) {
+    this.scatterMouseUp.emit({
+      nativeEvent: event,
+      payload: point.payload,
+      index,
+      value: point.payload,
+      coordinate: { x: point.x, y: point.y },
+    });
+  }
+
+  handleScatterMouseMove(event: MouseEvent, point: ScatterPoint, index: number) {
+    this.scatterMouseMove.emit({
+      nativeEvent: event,
+      payload: point.payload,
+      index,
+      value: point.payload,
+      coordinate: { x: point.x, y: point.y },
+    });
+  }
+
+  handleScatterMouseOver(event: MouseEvent, point: ScatterPoint, index: number) {
+    this.scatterMouseOver.emit({
+      nativeEvent: event,
+      payload: point.payload,
+      index,
+      value: point.payload,
+      coordinate: { x: point.x, y: point.y },
+    });
+  }
+
+  handleScatterMouseOut(event: MouseEvent, point: ScatterPoint, index: number) {
+    this.scatterMouseOut.emit({
       nativeEvent: event,
       payload: point.payload,
       index,

--- a/projects/ngx-recharts-lib/src/lib/polar/pie.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/polar/pie.component.ts
@@ -52,6 +52,11 @@ export interface PieSectorData {
           [animationDuration]="animationDuration()"
           [animationEasing]="animationEasing()"
           (sectorClick)="handleSectorClick($event, sector, $index)"
+          (sectorMouseDown)="handleSectorMouseDown($event, sector, $index)"
+          (sectorMouseUp)="handleSectorMouseUp($event, sector, $index)"
+          (sectorMouseMove)="handleSectorMouseMove($event, sector, $index)"
+          (sectorMouseOver)="handleSectorMouseOver($event, sector, $index)"
+          (sectorMouseOut)="handleSectorMouseOut($event, sector, $index)"
           (sectorMouseEnter)="handleSectorMouseEnter($event, sector, $index)"
           (sectorMouseLeave)="handleSectorMouseLeave($event, sector, $index)"
         />
@@ -96,6 +101,11 @@ export class PieComponent implements OnDestroy {
   animationEasing = input<string>('ease');
 
   pieClick = output<ChartMouseEvent>();
+  pieMouseDown = output<ChartMouseEvent>();
+  pieMouseUp = output<ChartMouseEvent>();
+  pieMouseMove = output<ChartMouseEvent>();
+  pieMouseOver = output<ChartMouseEvent>();
+  pieMouseOut = output<ChartMouseEvent>();
   pieMouseEnter = output<ChartMouseEvent>();
   pieMouseLeave = output<ChartMouseEvent>();
 
@@ -200,6 +210,56 @@ export class PieComponent implements OnDestroy {
 
   handleSectorMouseEnter(event: MouseEvent, sectorData: any, index: number) {
     this.pieMouseEnter.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: sectorData,
+      index,
+      value: sectorData?.value,
+    });
+  }
+
+  handleSectorMouseDown(event: MouseEvent, sectorData: any, index: number) {
+    this.pieMouseDown.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: sectorData,
+      index,
+      value: sectorData?.value,
+    });
+  }
+
+  handleSectorMouseUp(event: MouseEvent, sectorData: any, index: number) {
+    this.pieMouseUp.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: sectorData,
+      index,
+      value: sectorData?.value,
+    });
+  }
+
+  handleSectorMouseMove(event: MouseEvent, sectorData: any, index: number) {
+    this.pieMouseMove.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: sectorData,
+      index,
+      value: sectorData?.value,
+    });
+  }
+
+  handleSectorMouseOver(event: MouseEvent, sectorData: any, index: number) {
+    this.pieMouseOver.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey() as string,
+      payload: sectorData,
+      index,
+      value: sectorData?.value,
+    });
+  }
+
+  handleSectorMouseOut(event: MouseEvent, sectorData: any, index: number) {
+    this.pieMouseOut.emit({
       nativeEvent: event,
       dataKey: this.dataKey() as string,
       payload: sectorData,

--- a/projects/ngx-recharts-lib/src/lib/polar/radar.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/polar/radar.component.ts
@@ -29,6 +29,11 @@ interface RadarPoint {
     @if (!hide()) {
       <svg:g
         (click)="handleRadarClick($event)"
+        (mousedown)="handleRadarMouseDown($event)"
+        (mouseup)="handleRadarMouseUp($event)"
+        (mousemove)="handleRadarMouseMove($event)"
+        (mouseover)="handleRadarMouseOver($event)"
+        (mouseout)="handleRadarMouseOut($event)"
         (mouseenter)="handleRadarMouseEnter($event)"
         (mouseleave)="handleRadarMouseLeave($event)"
       >
@@ -111,6 +116,11 @@ export class RadarComponent implements OnDestroy {
 
   // Event outputs
   radarClick = output<ChartMouseEvent>();
+  radarMouseDown = output<ChartMouseEvent>();
+  radarMouseUp = output<ChartMouseEvent>();
+  radarMouseMove = output<ChartMouseEvent>();
+  radarMouseOver = output<ChartMouseEvent>();
+  radarMouseOut = output<ChartMouseEvent>();
   radarMouseEnter = output<ChartMouseEvent>();
   radarMouseLeave = output<ChartMouseEvent>();
 
@@ -125,6 +135,51 @@ export class RadarComponent implements OnDestroy {
 
   handleRadarMouseEnter(event: MouseEvent) {
     this.radarMouseEnter.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleRadarMouseDown(event: MouseEvent) {
+    this.radarMouseDown.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleRadarMouseUp(event: MouseEvent) {
+    this.radarMouseUp.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleRadarMouseMove(event: MouseEvent) {
+    this.radarMouseMove.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleRadarMouseOver(event: MouseEvent) {
+    this.radarMouseOver.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: this.resolvedData(),
+      index: 0,
+    });
+  }
+
+  handleRadarMouseOut(event: MouseEvent) {
+    this.radarMouseOut.emit({
       nativeEvent: event,
       dataKey: this.dataKey(),
       payload: this.resolvedData(),

--- a/projects/ngx-recharts-lib/src/lib/polar/radial-bar.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/polar/radial-bar.component.ts
@@ -63,6 +63,11 @@ export interface RadialBarEntry {
           [animationDuration]="animationDuration()"
           [animationEasing]="animationEasing()"
           (sectorClick)="handleRadialBarClick($event, bar, $index)"
+          (sectorMouseDown)="handleRadialBarMouseDown($event, bar, $index)"
+          (sectorMouseUp)="handleRadialBarMouseUp($event, bar, $index)"
+          (sectorMouseMove)="handleRadialBarMouseMove($event, bar, $index)"
+          (sectorMouseOver)="handleRadialBarMouseOver($event, bar, $index)"
+          (sectorMouseOut)="handleRadialBarMouseOut($event, bar, $index)"
           (sectorMouseEnter)="handleRadialBarMouseEnter($event, bar, $index)"
           (sectorMouseLeave)="handleRadialBarMouseLeave($event, bar, $index)"
         />
@@ -119,6 +124,11 @@ export class RadialBarComponent implements OnDestroy {
 
   // Event outputs
   radialBarClick = output<ChartMouseEvent>();
+  radialBarMouseDown = output<ChartMouseEvent>();
+  radialBarMouseUp = output<ChartMouseEvent>();
+  radialBarMouseMove = output<ChartMouseEvent>();
+  radialBarMouseOver = output<ChartMouseEvent>();
+  radialBarMouseOut = output<ChartMouseEvent>();
   radialBarMouseEnter = output<ChartMouseEvent>();
   radialBarMouseLeave = output<ChartMouseEvent>();
 
@@ -134,6 +144,56 @@ export class RadialBarComponent implements OnDestroy {
 
   handleRadialBarMouseEnter(event: MouseEvent, barData: RadialBarEntry, index: number) {
     this.radialBarMouseEnter.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: barData,
+      index,
+      value: barData.value,
+    });
+  }
+
+  handleRadialBarMouseDown(event: MouseEvent, barData: RadialBarEntry, index: number) {
+    this.radialBarMouseDown.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: barData,
+      index,
+      value: barData.value,
+    });
+  }
+
+  handleRadialBarMouseUp(event: MouseEvent, barData: RadialBarEntry, index: number) {
+    this.radialBarMouseUp.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: barData,
+      index,
+      value: barData.value,
+    });
+  }
+
+  handleRadialBarMouseMove(event: MouseEvent, barData: RadialBarEntry, index: number) {
+    this.radialBarMouseMove.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: barData,
+      index,
+      value: barData.value,
+    });
+  }
+
+  handleRadialBarMouseOver(event: MouseEvent, barData: RadialBarEntry, index: number) {
+    this.radialBarMouseOver.emit({
+      nativeEvent: event,
+      dataKey: this.dataKey(),
+      payload: barData,
+      index,
+      value: barData.value,
+    });
+  }
+
+  handleRadialBarMouseOut(event: MouseEvent, barData: RadialBarEntry, index: number) {
+    this.radialBarMouseOut.emit({
       nativeEvent: event,
       dataKey: this.dataKey(),
       payload: barData,

--- a/projects/ngx-recharts-lib/src/lib/shape/dot.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/shape/dot.component.ts
@@ -22,6 +22,11 @@ import {
         [attr.stroke-width]="strokeWidth()"
         [style]="animationStyle()"
         (click)="dotClick.emit($event)"
+        (mousedown)="dotMouseDown.emit($event)"
+        (mouseup)="dotMouseUp.emit($event)"
+        (mousemove)="dotMouseMove.emit($event)"
+        (mouseover)="dotMouseOver.emit($event)"
+        (mouseout)="dotMouseOut.emit($event)"
         (mouseenter)="dotMouseEnter.emit($event)"
         (mouseleave)="dotMouseLeave.emit($event)" />
     }
@@ -52,6 +57,11 @@ export class DotComponent {
   });
 
   dotClick = output<MouseEvent>();
+  dotMouseDown = output<MouseEvent>();
+  dotMouseUp = output<MouseEvent>();
+  dotMouseMove = output<MouseEvent>();
+  dotMouseOver = output<MouseEvent>();
+  dotMouseOut = output<MouseEvent>();
   dotMouseEnter = output<MouseEvent>();
   dotMouseLeave = output<MouseEvent>();
 

--- a/projects/ngx-recharts-lib/src/lib/shape/rectangle.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/shape/rectangle.component.ts
@@ -20,6 +20,11 @@ import {
         [class]="className()"
         [style]="animationStyle()"
         (click)="rectClick.emit($event)"
+        (mousedown)="rectMouseDown.emit($event)"
+        (mouseup)="rectMouseUp.emit($event)"
+        (mousemove)="rectMouseMove.emit($event)"
+        (mouseover)="rectMouseOver.emit($event)"
+        (mouseout)="rectMouseOut.emit($event)"
         (mouseenter)="rectMouseEnter.emit($event)"
         (mouseleave)="rectMouseLeave.emit($event)" />
     } @else if (isRenderable()) {
@@ -34,6 +39,11 @@ import {
         [class]="className()"
         [style]="animationStyle()"
         (click)="rectClick.emit($event)"
+        (mousedown)="rectMouseDown.emit($event)"
+        (mouseup)="rectMouseUp.emit($event)"
+        (mousemove)="rectMouseMove.emit($event)"
+        (mouseover)="rectMouseOver.emit($event)"
+        (mouseout)="rectMouseOut.emit($event)"
         (mouseenter)="rectMouseEnter.emit($event)"
         (mouseleave)="rectMouseLeave.emit($event)" />
     }
@@ -65,6 +75,11 @@ export class RectangleComponent {
   });
 
   rectClick = output<MouseEvent>();
+  rectMouseDown = output<MouseEvent>();
+  rectMouseUp = output<MouseEvent>();
+  rectMouseMove = output<MouseEvent>();
+  rectMouseOver = output<MouseEvent>();
+  rectMouseOut = output<MouseEvent>();
   rectMouseEnter = output<MouseEvent>();
   rectMouseLeave = output<MouseEvent>();
 

--- a/projects/ngx-recharts-lib/src/lib/shape/sector.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/shape/sector.component.ts
@@ -22,6 +22,11 @@ import { arc } from 'd3-shape';
         [class]="className()"
         [style]="animationStyle()"
         (click)="sectorClick.emit($event)"
+        (mousedown)="sectorMouseDown.emit($event)"
+        (mouseup)="sectorMouseUp.emit($event)"
+        (mousemove)="sectorMouseMove.emit($event)"
+        (mouseover)="sectorMouseOver.emit($event)"
+        (mouseout)="sectorMouseOut.emit($event)"
         (mouseenter)="sectorMouseEnter.emit($event)"
         (mouseleave)="sectorMouseLeave.emit($event)" />
     }
@@ -42,6 +47,11 @@ export class SectorComponent {
   className = input<string>('');
 
   sectorClick = output<MouseEvent>();
+  sectorMouseDown = output<MouseEvent>();
+  sectorMouseUp = output<MouseEvent>();
+  sectorMouseMove = output<MouseEvent>();
+  sectorMouseOver = output<MouseEvent>();
+  sectorMouseOut = output<MouseEvent>();
   sectorMouseEnter = output<MouseEvent>();
   sectorMouseLeave = output<MouseEvent>();
 

--- a/projects/ngx-recharts-lib/src/lib/shape/symbols.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/shape/symbols.component.ts
@@ -33,6 +33,11 @@ export type SymbolType = 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 't
       [attr.transform]="transform()"
       [style]="animationStyle()"
       (click)="symbolClick.emit($event)"
+      (mousedown)="symbolMouseDown.emit($event)"
+      (mouseup)="symbolMouseUp.emit($event)"
+      (mousemove)="symbolMouseMove.emit($event)"
+      (mouseover)="symbolMouseOver.emit($event)"
+      (mouseout)="symbolMouseOut.emit($event)"
       (mouseenter)="symbolMouseEnter.emit($event)"
       (mouseleave)="symbolMouseLeave.emit($event)" />
     }
@@ -63,6 +68,11 @@ export class SymbolsComponent {
   });
 
   symbolClick = output<MouseEvent>();
+  symbolMouseDown = output<MouseEvent>();
+  symbolMouseUp = output<MouseEvent>();
+  symbolMouseMove = output<MouseEvent>();
+  symbolMouseOver = output<MouseEvent>();
+  symbolMouseOut = output<MouseEvent>();
   symbolMouseEnter = output<MouseEvent>();
   symbolMouseLeave = output<MouseEvent>();
 

--- a/projects/ngx-recharts-lib/src/lib/shape/trapezoid.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/shape/trapezoid.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   computed,
   input,
+  output,
 } from '@angular/core';
 
 @Component({
@@ -17,7 +18,15 @@ import {
         [attr.stroke]="stroke()"
         [attr.stroke-width]="strokeWidth()"
         [class]="className()"
-        [style]="animationStyle()" />
+        [style]="animationStyle()"
+        (click)="trapezoidClick.emit($event)"
+        (mousedown)="trapezoidMouseDown.emit($event)"
+        (mouseup)="trapezoidMouseUp.emit($event)"
+        (mousemove)="trapezoidMouseMove.emit($event)"
+        (mouseover)="trapezoidMouseOver.emit($event)"
+        (mouseout)="trapezoidMouseOut.emit($event)"
+        (mouseenter)="trapezoidMouseEnter.emit($event)"
+        (mouseleave)="trapezoidMouseLeave.emit($event)" />
     }
   `,
 })
@@ -31,6 +40,15 @@ export class TrapezoidComponent {
   stroke = input<string>('none');
   strokeWidth = input<number>(1);
   className = input<string>('');
+
+  trapezoidClick = output<MouseEvent>();
+  trapezoidMouseDown = output<MouseEvent>();
+  trapezoidMouseUp = output<MouseEvent>();
+  trapezoidMouseMove = output<MouseEvent>();
+  trapezoidMouseOver = output<MouseEvent>();
+  trapezoidMouseOut = output<MouseEvent>();
+  trapezoidMouseEnter = output<MouseEvent>();
+  trapezoidMouseLeave = output<MouseEvent>();
 
   // Animation inputs
   isAnimationActive = input<boolean>(true);


### PR DESCRIPTION
## Summary
- Add 5 missing mouse events (mousedown, mouseup, mousemove, mouseover, mouseout) to all 16 data-rendering components, matching LineComponent's complete 8-event coverage
- Add all 8 events to TrapezoidComponent and 3 reference components (ReferenceDot, ReferenceLine, ReferenceArea) which previously had zero events
- Shape components emit `output<MouseEvent>()`; data/reference components emit `output<ChartMouseEvent>()`

Closes #10

## Files Modified (15)
**Shape components (5):** symbols, sector, dot, rectangle, trapezoid  
**Data components (7):** funnel, radar, pie, radial-bar, bar, area, scatter  
**Reference components (3):** reference-dot, reference-line, reference-area

## Verification
- All 5 shape components: 8 `output<MouseEvent>()` each (40 total)
- All 11 data/reference components: 8 `output<ChartMouseEvent>()` each (88 total)
- shape-guards tests: 19/19 passing
- Build: compiles with zero errors from modified files (pre-existing errors in unrelated sankey/treemap/sunburst files are unchanged)

## Test plan
- [x] `npx ng test ngx-recharts-lib --include='**/shape-guards*' --watch=false` passes (19/19)
- [x] Grep verification: every target component has exactly 8 output declarations
- [x] No existing event names or types changed (backward compatible)
- [x] Events bind on the same element type as before (wrapper `<g>` stays wrapper `<g>`, direct SVG stays direct SVG)