### PR TITLE
feat: add clipPath support for data overflow clipping

### DIFF
--- a/projects/ngx-recharts-lib/src/lib/cartesian/area.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/area.component.ts
@@ -16,6 +16,7 @@ import { CHART_TOOLTIP_SERVICE } from '../core/chart-context.token';
 import { GraphicalItemRegistryService } from '../services/graphical-item-registry.service';
 import { createChartDimensions } from '../shared/chart-dimensions';
 import { ChartDataService } from '../services/chart-data.service';
+import { ClipPathService } from '../services/clip-path.service';
 import {
   line as d3Line,
   area as d3Area,
@@ -43,6 +44,9 @@ export interface AreaPoint {
   selector: 'svg:g[ngx-area]',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[attr.clip-path]': 'clipPathService?.shouldClip() ? clipPathService.clipPathUrl() : null',
+  },
   template: `
     @if (!hide() && points().length > 0) {
       <!-- Area path -->
@@ -104,6 +108,7 @@ export class AreaComponent implements OnDestroy {
   private tooltipService = inject(CHART_TOOLTIP_SERVICE, { optional: true });
   private registryService = inject(GraphicalItemRegistryService, { optional: true });
   private chartDataService = inject(ChartDataService, { optional: true });
+  clipPathService = inject(ClipPathService, { optional: true });
 
   private static nextId = 0;
   private readonly itemId = `area-${AreaComponent.nextId++}`;

--- a/projects/ngx-recharts-lib/src/lib/cartesian/bar.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/bar.component.ts
@@ -15,6 +15,7 @@ import { ResponsiveContainerService } from '../services/responsive-container.ser
 import { GraphicalItemRegistryService } from '../services/graphical-item-registry.service';
 import { createChartDimensions } from '../shared/chart-dimensions';
 import { ChartDataService } from '../services/chart-data.service';
+import { ClipPathService } from '../services/clip-path.service';
 import { stack as d3Stack } from 'd3-shape';
 import { getD3StackOffset } from '../shared/d3-helpers';
 
@@ -31,6 +32,9 @@ export interface BarRect {
   selector: 'svg:g[ngx-bar]',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[attr.clip-path]': 'clipPathService?.shouldClip() ? clipPathService.clipPathUrl() : null',
+  },
   template: `
     @if (!hide() && bars().length > 0) {
       @for (bar of bars(); track $index) {
@@ -77,6 +81,7 @@ export class BarComponent implements OnDestroy {
   private responsiveService = inject(ResponsiveContainerService, { optional: true });
   private registryService = inject(GraphicalItemRegistryService, { optional: true });
   private chartDataService = inject(ChartDataService, { optional: true });
+  clipPathService = inject(ClipPathService, { optional: true });
 
   private static nextId = 0;
   private readonly itemId = `bar-${BarComponent.nextId++}`;

--- a/projects/ngx-recharts-lib/src/lib/cartesian/cartesian-axis.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/cartesian-axis.component.ts
@@ -160,6 +160,7 @@ export class CartesianAxisComponent implements OnDestroy {
         range: [0, 0],
         ticks: this.ticks?.() ?? [],
         dataKey: this.dataKey(),
+        allowDataOverflow: this.allowDataOverflow(),
       });
     });
   }

--- a/projects/ngx-recharts-lib/src/lib/cartesian/line.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/line.component.ts
@@ -17,6 +17,7 @@ import { CHART_TOOLTIP_SERVICE } from '../core/chart-context.token';
 import { GraphicalItemRegistryService } from '../services/graphical-item-registry.service';
 import { createChartDimensions } from '../shared/chart-dimensions';
 import { ChartDataService } from '../services/chart-data.service';
+import { ClipPathService } from '../services/clip-path.service';
 
 export interface LinePoint {
   x: number;
@@ -29,6 +30,9 @@ export interface LinePoint {
   selector: 'svg:g[ngx-line]',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[attr.clip-path]': 'clipPathService?.shouldClip() ? clipPathService.clipPathUrl() : null',
+  },
   template: `
     @if (!hide() && finalPoints().length > 0) {
       <!-- Line path -->
@@ -88,6 +92,7 @@ export class LineComponent implements OnDestroy {
   private tooltipService = inject(CHART_TOOLTIP_SERVICE, { optional: true });
   private registryService = inject(GraphicalItemRegistryService, { optional: true });
   private chartDataService = inject(ChartDataService, { optional: true });
+  clipPathService = inject(ClipPathService, { optional: true });
 
   private static nextId = 0;
   private readonly itemId = `line-${LineComponent.nextId++}`;

--- a/projects/ngx-recharts-lib/src/lib/cartesian/scatter.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/cartesian/scatter.component.ts
@@ -15,6 +15,7 @@ import { GraphicalItemRegistryService } from '../services/graphical-item-registr
 import { ResponsiveContainerService } from '../services/responsive-container.service';
 import { ScaleService } from '../services/scale.service';
 import { createChartDimensions } from '../shared/chart-dimensions';
+import { ClipPathService } from '../services/clip-path.service';
 import { SymbolsComponent, SymbolType } from '../shape/symbols.component';
 import { CurveComponent, CurveType } from '../shape/curve.component';
 
@@ -30,6 +31,9 @@ export interface ScatterPoint {
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [SymbolsComponent, CurveComponent],
+  host: {
+    '[attr.clip-path]': 'clipPathService?.shouldClip() ? clipPathService.clipPathUrl() : null',
+  },
   template: `
     @if (!hide()) {
       @if (line()) {
@@ -61,6 +65,7 @@ export class ScatterComponent implements OnDestroy {
   private registryService = inject(GraphicalItemRegistryService, { optional: true });
   private responsiveService = inject(ResponsiveContainerService, { optional: true });
   private scaleService = inject(ScaleService);
+  clipPathService = inject(ClipPathService, { optional: true });
 
   private static nextId = 0;
   private readonly itemId = `scatter-${ScatterComponent.nextId++}`;

--- a/projects/ngx-recharts-lib/src/lib/chart/area-chart.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/chart/area-chart.component.ts
@@ -21,6 +21,7 @@ import { ChartDataService, YDomainMode, StackOffsetType } from '../services/char
 import { CartesianLabelContextService } from '../context/label-context.service';
 import { CartesianLabelListContextService } from '../context/label-list-context.service';
 import { AxisRegistryService } from '../services/axis-registry.service';
+import { ClipPathService } from '../services/clip-path.service';
 
 @Component({
   selector: 'ngx-area-chart',
@@ -38,6 +39,7 @@ import { AxisRegistryService } from '../services/axis-registry.service';
     CartesianLabelContextService,
     CartesianLabelListContextService,
     AxisRegistryService,
+    ClipPathService,
     {
       provide: CHART_TOOLTIP_SERVICE,
       useExisting: TooltipService,

--- a/projects/ngx-recharts-lib/src/lib/chart/bar-chart.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/chart/bar-chart.component.ts
@@ -21,6 +21,7 @@ import { ChartDataService, YDomainMode, StackOffsetType } from '../services/char
 import { CartesianLabelContextService } from '../context/label-context.service';
 import { CartesianLabelListContextService } from '../context/label-list-context.service';
 import { AxisRegistryService } from '../services/axis-registry.service';
+import { ClipPathService } from '../services/clip-path.service';
 
 @Component({
   selector: 'ngx-bar-chart',
@@ -38,6 +39,7 @@ import { AxisRegistryService } from '../services/axis-registry.service';
     CartesianLabelContextService,
     CartesianLabelListContextService,
     AxisRegistryService,
+    ClipPathService,
     {
       provide: CHART_TOOLTIP_SERVICE,
       useExisting: TooltipService,

--- a/projects/ngx-recharts-lib/src/lib/chart/composed-chart.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/chart/composed-chart.component.ts
@@ -21,6 +21,7 @@ import { ChartDataService, YDomainMode, StackOffsetType } from '../services/char
 import { CartesianLabelContextService } from '../context/label-context.service';
 import { CartesianLabelListContextService } from '../context/label-list-context.service';
 import { AxisRegistryService } from '../services/axis-registry.service';
+import { ClipPathService } from '../services/clip-path.service';
 
 @Component({
   selector: 'ngx-composed-chart',
@@ -35,6 +36,7 @@ import { AxisRegistryService } from '../services/axis-registry.service';
     CartesianLabelContextService,
     CartesianLabelListContextService,
     AxisRegistryService,
+    ClipPathService,
     {
       provide: CHART_TOOLTIP_SERVICE,
       useExisting: TooltipService,

--- a/projects/ngx-recharts-lib/src/lib/chart/line-chart.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/chart/line-chart.component.ts
@@ -21,6 +21,7 @@ import { ChartDataService, YDomainMode } from '../services/chart-data.service';
 import { CartesianLabelContextService } from '../context/label-context.service';
 import { CartesianLabelListContextService } from '../context/label-list-context.service';
 import { AxisRegistryService } from '../services/axis-registry.service';
+import { ClipPathService } from '../services/clip-path.service';
 
 
 @Component({
@@ -36,6 +37,7 @@ import { AxisRegistryService } from '../services/axis-registry.service';
     CartesianLabelContextService,
     CartesianLabelListContextService,
     AxisRegistryService,
+    ClipPathService,
     {
       provide: CHART_TOOLTIP_SERVICE,
       useExisting: TooltipService,

--- a/projects/ngx-recharts-lib/src/lib/chart/scatter-chart.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/chart/scatter-chart.component.ts
@@ -19,6 +19,7 @@ import { TooltipService } from '../services/tooltip.service';
 import { GraphicalItemRegistryService } from '../services/graphical-item-registry.service';
 import { ChartDataService } from '../services/chart-data.service';
 import { AxisRegistryService } from '../services/axis-registry.service';
+import { ClipPathService } from '../services/clip-path.service';
 import { CartesianLabelContextService } from '../context/label-context.service';
 import { CartesianLabelListContextService } from '../context/label-list-context.service';
 
@@ -35,6 +36,7 @@ import { CartesianLabelListContextService } from '../context/label-list-context.
     GraphicalItemRegistryService,
     ResponsiveContainerService,
     AxisRegistryService,
+    ClipPathService,
     CartesianLabelContextService,
     CartesianLabelListContextService,
     {

--- a/projects/ngx-recharts-lib/src/lib/container/surface.component.ts
+++ b/projects/ngx-recharts-lib/src/lib/container/surface.component.ts
@@ -11,6 +11,8 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ChartLayoutService } from '../services/chart-layout.service';
+import { ClipPathService } from '../services/clip-path.service';
+import { ResponsiveContainerService } from '../services/responsive-container.service';
 
 @Component({
   selector: 'ngx-recharts-surface',
@@ -33,6 +35,18 @@ import { ChartLayoutService } from '../services/chart-layout.service';
       @if (desc()) {
         <svg:desc>{{ desc() }}</svg:desc>
       }
+      @if (clipPathService?.shouldClip()) {
+        <svg:defs>
+          <svg:clipPath [attr.id]="clipPathService!.clipPathId">
+            <svg:rect
+              [attr.x]="clipX()"
+              [attr.y]="clipY()"
+              [attr.width]="clipWidth()"
+              [attr.height]="clipHeight()"
+            />
+          </svg:clipPath>
+        </svg:defs>
+      }
       <ng-content></ng-content>
     </svg>
   `,
@@ -45,6 +59,8 @@ import { ChartLayoutService } from '../services/chart-layout.service';
 })
 export class SurfaceComponent {
   private layoutService = inject(ChartLayoutService, { optional: true });
+  clipPathService = inject(ClipPathService, { optional: true });
+  private responsiveService = inject(ResponsiveContainerService, { optional: true });
 
   // Inputs using new signal-based inputs
   width = input<number>(0);
@@ -59,6 +75,12 @@ export class SurfaceComponent {
 
   // Computed viewBox — uses input override if provided, else auto-computed
   resolvedViewBox = computed(() => this.viewBox() ?? `0 0 ${this.width()} ${this.height()}`);
+
+  // Clip rect coordinates (absolute SVG coordinates)
+  clipX = computed(() => this.responsiveService?.totalOffset().left ?? 0);
+  clipY = computed(() => this.responsiveService?.totalOffset().top ?? 0);
+  clipWidth = computed(() => this.responsiveService?.plotWidth() ?? this.width());
+  clipHeight = computed(() => this.responsiveService?.plotHeight() ?? this.height());
 
   // Output events
   dimensionsChange = output<{ width: number; height: number }>();

--- a/projects/ngx-recharts-lib/src/lib/services/axis-registry.service.ts
+++ b/projects/ngx-recharts-lib/src/lib/services/axis-registry.service.ts
@@ -9,6 +9,7 @@ export interface AxisRegistration {
   ticks: any[];
   dataKey?: string;
   orientation?: string;
+  allowDataOverflow?: boolean;
 }
 
 @Injectable()

--- a/projects/ngx-recharts-lib/src/lib/services/clip-path.service.ts
+++ b/projects/ngx-recharts-lib/src/lib/services/clip-path.service.ts
@@ -1,0 +1,23 @@
+import { computed, inject, Injectable } from '@angular/core';
+import { AxisRegistryService } from './axis-registry.service';
+
+let nextChartId = 0;
+
+@Injectable()
+export class ClipPathService {
+  private axisRegistry = inject(AxisRegistryService);
+
+  readonly clipPathId = `recharts-clip-${nextChartId++}`;
+
+  readonly clipPathUrl = computed(() => `url(#${this.clipPathId})`);
+
+  readonly shouldClip = computed(() => {
+    const axes = this.axisRegistry.axes();
+    for (const registration of axes.values()) {
+      if (registration.allowDataOverflow) {
+        return true;
+      }
+    }
+    return false;
+  });
+}

--- a/projects/ngx-recharts-lib/src/public-api.ts
+++ b/projects/ngx-recharts-lib/src/public-api.ts
@@ -17,6 +17,7 @@ export * from './lib/services/axis-domain.service';
 export * from './lib/services/axis-scale.service';
 export * from './lib/services/chart-data.service';
 export * from './lib/services/responsive-container.service';
+export * from './lib/services/clip-path.service';
 
 // Chart Components
 export * from './lib/chart/line-chart.component';


### PR DESCRIPTION
## Summary

- Create `ClipPathService` that generates unique clip path IDs per chart instance and derives `shouldClip` from axis registrations with `allowDataOverflow: true`
- Render `<defs><clipPath>` as a direct child of `<svg>` in `SurfaceComponent`, using absolute SVG coordinates from `ResponsiveContainerService`
- Apply `clip-path` host binding to all 4 graphical components (Line, Area, Bar, Scatter) so elements are clipped to the plot area when any axis has `allowDataOverflow` enabled
- Provide `ClipPathService` in all 5 cartesian chart components (LineChart, BarChart, AreaChart, ScatterChart, ComposedChart)
- Add `allowDataOverflow` to `AxisRegistration` interface and propagate from `CartesianAxisComponent`

## Test plan

- [x] All 76 existing tests pass with no regressions
- [x] Build compiles cleanly (no new errors; pre-existing d3-hierarchy/d3-sankey type errors unrelated)
- [ ] Verify `<clipPath>` appears in DOM when `[allowDataOverflow]="true"` is set on an axis
- [ ] Verify no `<clipPath>` markup when no axis has `allowDataOverflow`
- [ ] Verify Line, Area, Bar, Scatter elements have `clip-path` attribute when clipping is active
- [ ] Verify multiple charts on the same page get unique clip path IDs (no collisions)

Closes #6